### PR TITLE
Users can complete a form to pay for a penalty charge notice

### DIFF
--- a/db/migrate/20180705135129_create_payments.rb
+++ b/db/migrate/20180705135129_create_payments.rb
@@ -5,6 +5,7 @@ class CreatePayments < ActiveRecord::Migration[5.2]
       t.string :govpay_reference
       t.integer :amount
       t.string :status
+      t.string :govpay_url
       t.string :govpay_payment_id
     end
   end

--- a/db/migrate/20180706110213_create_penalty_charge_notices.rb
+++ b/db/migrate/20180706110213_create_penalty_charge_notices.rb
@@ -1,0 +1,10 @@
+class CreatePenaltyChargeNotices < ActiveRecord::Migration[5.2]
+  def change
+    create_table :penalty_charge_notices do |t|
+      t.string :pcn_number
+      t.string :vehicle_registration_mark
+      t.references :payment, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_05_135129) do
+ActiveRecord::Schema.define(version: 2018_07_06_110213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,17 @@ ActiveRecord::Schema.define(version: 2018_07_05_135129) do
     t.string "govpay_reference"
     t.integer "amount"
     t.string "status"
+    t.string "govpay_url"
     t.string "govpay_payment_id"
+  end
+
+  create_table "penalty_charge_notices", force: :cascade do |t|
+    t.string "pcn_number"
+    t.string "vehicle_registration_mark"
+    t.bigint "payment_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["payment_id"], name: "index_penalty_charge_notices_on_payment_id"
   end
 
 end

--- a/models/payment.rb
+++ b/models/payment.rb
@@ -1,3 +1,5 @@
+require 'govuk_pay_api_client'
+
 class Payment < ActiveRecord::Base
   validates_presence_of :description
   validates_presence_of :govpay_reference
@@ -5,5 +7,34 @@ class Payment < ActiveRecord::Base
 
   def successful?
     status == 'success'
+  end
+
+  def pending?
+    status == 'pending'
+  end
+
+  def failed?
+    status == 'failed'
+  end
+
+  def update_govpay_status
+    return if pending?
+    GovukPayApiClient::GetStatus.call(self).tap do |govpay_response|
+      update(status: govpay_response.status)
+    end
+  end
+
+  def create_govpay_payment(return_url:)
+    return unless pending?
+    GovukPayApiClient::CreatePayment.call(
+      self,
+      return_url
+    ).tap do |govpay_response|
+      update(
+        govpay_payment_id: govpay_response.payment_id,
+        govpay_url: govpay_response.next_url,
+        status: :created
+      )
+    end
   end
 end

--- a/models/payment.rb
+++ b/models/payment.rb
@@ -25,7 +25,6 @@ class Payment < ActiveRecord::Base
   end
 
   def create_govpay_payment(return_url:)
-    return unless pending?
     GovukPayApiClient::CreatePayment.call(
       self,
       return_url

--- a/models/penalty_charge_notice.rb
+++ b/models/penalty_charge_notice.rb
@@ -1,4 +1,6 @@
 class PenaltyChargeNotice < ActiveRecord::Base
   validates_presence_of :pcn_number
   validates_presence_of :vehicle_registration_mark
+
+  belongs_to :payment
 end

--- a/models/penalty_charge_notice.rb
+++ b/models/penalty_charge_notice.rb
@@ -1,0 +1,4 @@
+class PenaltyChargeNotice < ActiveRecord::Base
+  validates_presence_of :pcn_number
+  validates_presence_of :vehicle_registration_mark
+end

--- a/views/pay_now.haml
+++ b/views/pay_now.haml
@@ -1,6 +1,29 @@
-%h1 Welcome to Scarfolk Council
-%p To complete your temporary event notice application, please proceed to payment.
+.govuk-width-container
+  .govuk-main-wrapper
+    .govuk-grid-row
+      .govuk-grid-column-two-thirds
+        %h1.govuk-heading-xl Penalty charge details
+        %form{action: '/', method: 'post'}
+          .govuk-form-group
+            %label.govuk-label.govuk-label--m{for: 'pcn-number'}
+              Penalty Charge Notice (PCN) number
+            %span#pcn-number-hint.govuk-hint
+              For example, ABC 123 456
+            %input#pcn-number.govuk-input.govuk-input--width-20{'aria-describedby' => 'pcn-number-hint', name: 'pcn-number', type: 'text'}
+            %details.govuk-details{class: 'govuk-!-padding-top-3'}
+              %summary.govuk-details__summary
+                %span.govuk-details__summary-text
+                  Where can I find my PCN number?
+              .govuk-details__text
+                The PCN number can be found above the vehicle image in the top right hand corner of the PCN.
+          .govuk-form-group
+            %fieldset.govuk-fieldset{'aria-describedby' => 'registration-number-hint', role: 'group'}
+              %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+                Vehicle Registration Mark
+              %span#registration-number-hint.govuk-hint
+                For example, MH55 ALB
+              %input#registration-number.govuk-input.govuk-input--width-10{'aria-describedby' => 'registration-number-hint', name: 'pcn-number', type: 'text'}
 
-%form{ action: url('/'), method: :post }
-  %button.govuk-button{ type: :submit } Pay now
+          %button.govuk-button{type: 'submit'}
+            Pay now
 

--- a/views/payment.haml
+++ b/views/payment.haml
@@ -9,4 +9,34 @@
   %p
     %a.govuk-back-link{ href: '/'} Back to homepage
 - else
-  %h1 There was a problem with your payment
+  %h1 Your Penalty Charge details
+
+  - if @payment.failed?
+    .govuk-error-summary{'aria-labelledby' => 'error-summary-title', 'data-module' => 'error-summary', role: 'alert', tabindex: '-1'}
+      %h2#error-summary-title.govuk-error-summary__title
+        There was a problem with your payment
+      .govuk-error-summary__body
+        %ul.govuk-list.govuk-error-summary__list
+          %li You were not charged and can attempt the payment again
+
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      %table.govuk-table
+        %tbody.govuk-table__body
+          %tr.govuk-table__row
+            %th.govuk-table__header{:scope => "row"} Penalty Charge Notice (PCN) number
+            %td.govuk-table__cell= @pcn.pcn_number
+          %tr.govuk-table__row
+            %th.govuk-table__header{:scope => "row"} Vehicle Registration Mark
+            %td.govuk-table__cell= @pcn.vehicle_registration_mark
+          %tr.govuk-table__row
+            %th.govuk-table__header{:scope => "row"} Total amount payable
+            %td.govuk-table__cell= "£#{@pcn.payment.amount / 100}"
+
+
+      %form{action: "/penalty-charge-notice/#{@pcn.payment.govpay_reference}/pay", method: 'post'}
+        %button.govuk-button{type: 'submit'}
+          Pay now
+
+
+

--- a/views/penalty_charge_notice.haml
+++ b/views/penalty_charge_notice.haml
@@ -3,13 +3,23 @@
     .govuk-grid-row
       .govuk-grid-column-two-thirds
         %h1.govuk-heading-xl Penalty charge details
-        %form{action: '/', method: 'post'}
+
+        - if @pcn.errors.any?
+          .govuk-error-summary{'aria-labelledby' => 'error-summary-title', 'data-module' => 'error-summary', role: 'alert', tabindex: '-1'}
+            %h2#error-summary-title.govuk-error-summary__title
+              There is a problem
+            .govuk-error-summary__body
+              %ul.govuk-list.govuk-error-summary__list
+                - @pcn.errors.full_messages.each do |error|
+                  %li= error
+
+        %form{action: '/penalty-charge-notice', method: 'post'}
           .govuk-form-group
             %label.govuk-label.govuk-label--m{for: 'pcn-number'}
               Penalty Charge Notice (PCN) number
             %span#pcn-number-hint.govuk-hint
               For example, ABC 123 456
-            %input#pcn-number.govuk-input.govuk-input--width-20{'aria-describedby' => 'pcn-number-hint', name: 'pcn-number', type: 'text'}
+            %input#pcn-number.govuk-input.govuk-input--width-20{'aria-describedby' => 'pcn-number-hint', name: 'pcn_number', type: 'text'}
             %details.govuk-details{class: 'govuk-!-padding-top-3'}
               %summary.govuk-details__summary
                 %span.govuk-details__summary-text
@@ -17,12 +27,12 @@
               .govuk-details__text
                 The PCN number can be found above the vehicle image in the top right hand corner of the PCN.
           .govuk-form-group
-            %fieldset.govuk-fieldset{'aria-describedby' => 'registration-number-hint', role: 'group'}
+            %fieldset.govuk-fieldset{'aria-describedby' => 'registration-mark-hint', role: 'group'}
               %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
                 Vehicle Registration Mark
-              %span#registration-number-hint.govuk-hint
+              %span#registration-mark-hint.govuk-hint
                 For example, MH55 ALB
-              %input#registration-number.govuk-input.govuk-input--width-10{'aria-describedby' => 'registration-number-hint', name: 'pcn-number', type: 'text'}
+              %input#registration-mark.govuk-input.govuk-input--width-10{'aria-describedby' => 'registration-mark-hint', name: 'registration_mark', type: 'text'}
 
           %button.govuk-button{type: 'submit'}
             Pay now

--- a/views/penalty_charge_notice.haml
+++ b/views/penalty_charge_notice.haml
@@ -35,5 +35,5 @@
               %input#registration-mark.govuk-input.govuk-input--width-10{'aria-describedby' => 'registration-mark-hint', name: 'registration_mark', type: 'text'}
 
           %button.govuk-button{type: 'submit'}
-            Pay now
+            Continue
 


### PR DESCRIPTION
# User need

As a user
I need to pay for a penalty charge notice
So that I can avoid paying more fines

# What

There's a slight difference to the [User Journey diagram](https://www.figma.com/file/awm781b9TgMQnngrIVmMR3vC/User-journey-diagram) in that we can't tell the difference between a cancelled payment and a failed one, so we need to give a generic error message to the user instead.

Failed payment status:
> User attempted to make a payment but the payment did not complete. Possible reasons: user cancelled; user entered payment details but never confirmed; payment declined due to insufficent funds; payment declined due to fraud or other checks

https://docs.payments.service.gov.uk/#payment-status-lifecycle

# Screenshots

## PCN form
![image](https://user-images.githubusercontent.com/2804149/42518298-6fbca57a-8459-11e8-9384-f8984035d3c4.png)

## Validation failed
![image](https://user-images.githubusercontent.com/2804149/42518492-d9170eac-8459-11e8-9f7d-ed25959a0cb9.png)

## Confirmation
![image](https://user-images.githubusercontent.com/2804149/42518412-afae66dc-8459-11e8-823b-bfde37afbd18.png)

## Payment failed
![image](https://user-images.githubusercontent.com/2804149/42518253-51a2f4d6-8459-11e8-8c0b-01cc2cd5c862.png)
