### PR TITLE
(chore) Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .byebug_history
 .bundle
+.DS_Store
 node_modules
 *.sqlite3
 .env


### PR DESCRIPTION
Git ignore file needs to ignore the `.DS_store` files that appear on MacOS.